### PR TITLE
[fix] Fix out of bound error of userRewardLevel by Add prevent userIs…

### DIFF
--- a/src/main/java/com/mozi/moziserver/service/ScheduleService.java
+++ b/src/main/java/com/mozi/moziserver/service/ScheduleService.java
@@ -129,7 +129,10 @@ public class ScheduleService {
                         Animal nextAnimal = animalRepository.findByIslandTypeAndIslandLevel(lastPostboxMessageAnimal.getAnimal().getIslandType(), lastPostboxMessageAnimal.getAnimal().getIslandLevel() + 1);
                         postboxMessageAnimalService.createPostboxMessageAnimal(user, nextAnimal);
                     }
-                    userIslandRepository.updateUserIslandRewardLevel(user.getSeq(),lastPostboxMessageAnimal.getAnimal().getIslandType());
+
+                    if (lastPostboxMessageAnimal.getAnimal().getIslandLevel() < Constant.islandMaxLevel) {
+                        userIslandRepository.updateUserIslandRewardLevel(user.getSeq(), lastPostboxMessageAnimal.getAnimal().getIslandType());
+                    }
                 }
 
                 userNoticeService.upsertUserNotice(user, UserNoticeType.POSTBOX_MESSAGE_ANIMAL_RECEIVED_ITEM, lastPostboxMessageAnimal.getSeq());


### PR DESCRIPTION
## 개요 
- Issue #22
- UserIsland의 rewardLevel이 범주를 초과하여 업데이트 되는 문제 해결

### 세부 작업 내용
- updateUserIslandLevel 호출시 조건문 추가

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/#22 -> dev
