### PR TITLE
[feat] #13 - Add setting for sentry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ dependencies {
     implementation 'co.elastic.apm:apm-agent-api:1.34.0'
     implementation 'co.elastic.apm:apm-agent-attach:1.34.0'
 
+    implementation 'io.sentry:sentry-spring-boot-starter:6.11.0'
+    implementation 'io.sentry:sentry-logback:6.11.0'
+
     compileOnly 'org.projectlombok:lombok'
     //developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'mysql:mysql-connector-java'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,3 +52,9 @@ cloud:
 
 server:
   port: 8080
+
+sentry:
+  dsn: ${SENTRY_DSN}
+  stacktrace:
+    app-packages:
+      - com.mozi.moziserver

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -16,6 +16,12 @@
         </layout>
     </appender>
 
+    <appender name="Sentry" class="io.sentry.logback.SentryAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
+
     <springProfile name="default">
         <root level="INFO">
             <appender-ref ref="STDOUT" />
@@ -25,6 +31,7 @@
     <springProfile name="dev">
         <root level="INFO">
             <appender-ref ref="STDOUT" />
+            <appender-ref ref="Sentry" />
         </root>
         <logger name="com.mozi.moziserver.log.ApiLogFilter" level="INFO" additivity="false">
             <appender-ref ref="JSON" />
@@ -34,6 +41,7 @@
     <springProfile name="production">
         <root level="INFO">
             <appender-ref ref="STDOUT" />
+            <appender-ref ref="Sentry" />
         </root>
         <logger name="com.mozi.moziserver.log.ApiLogFilter" level="INFO" additivity="false">
             <appender-ref ref="JSON" />


### PR DESCRIPTION
## 개요 
- Issue #13 
- Sentry와 프로젝트 연결을 위한 Spring Boot 환경 설정

### 세부 작업 내용
- Gradle 의존성 추가
- logback-spring.xml에서 Sentry에 로그 레벨을 Error로 설정
- production와 develop에 적용하기 위해 <appender-ref ref="Sentry" /> 추가

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/#13 -> dev

### 테스트 결과 (optional)

### 특이 사항 (optional)
- 환경변수 추가되었습니다. {SENTRY_DNS}