### PR TITLE
Feature/#24

### DIFF
--- a/src/main/java/com/mozi/moziserver/controller/UserController.java
+++ b/src/main/java/com/mozi/moziserver/controller/UserController.java
@@ -134,10 +134,6 @@ public class UserController {
             @ApiParam(hidden = true) @SessionUser Long userSeq,
             @RequestBody @Valid ReqFcmToken reqFcmToken
     ) {
-        if (!userSeq.equals(userSeq)) {
-            throw ResponseError.Forbidden.NO_AUTHORITY.getResponseException();
-        }
-
         User user = userService.getUserBySeq(userSeq)
                 .orElseThrow(ResponseError.InternalServerError.UNEXPECTED_ERROR::getResponseException);
 

--- a/src/main/java/com/mozi/moziserver/model/entity/UserFcm.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/UserFcm.java
@@ -1,7 +1,6 @@
 package com.mozi.moziserver.model.entity;
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import javax.persistence.*;
 import javax.swing.text.StyledEditorKit;
@@ -12,6 +11,9 @@ import javax.swing.text.StyledEditorKit;
  */
 @Getter
 @Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 @Entity(name = "user_fcm")
 public class UserFcm extends AbstractTimeEntity {
     @Id

--- a/src/main/java/com/mozi/moziserver/model/mappedenum/FcmMessageType.java
+++ b/src/main/java/com/mozi/moziserver/model/mappedenum/FcmMessageType.java
@@ -8,8 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum FcmMessageType {
     NEW_POST_BOX_MESSAGE(true),
     END_USER_CHALLENGE_MESSAGE(true),
-    USER_NOTICE_POSTBOX_MESSAGE_ANIMAL_MESSAGE(true);
-
+    POSTBOX_MESSAGE_ANIMAL_RECEIVED_ITEM(true),
+    POSTBOX_MESSAGE_ANIMAL_NEW_ARRIVED(true);
 
     private final boolean isSilent;
 }

--- a/src/main/java/com/mozi/moziserver/repository/UserFcmRepository.java
+++ b/src/main/java/com/mozi/moziserver/repository/UserFcmRepository.java
@@ -12,7 +12,6 @@ import java.util.Optional;
 
 @Repository
 public interface UserFcmRepository extends JpaRepository<UserFcm, Long> {
-    Optional<UserFcm> findUserFcmByUser(User user);
+    Optional<UserFcm> findByUser(User user);
     UserFcm findByToken(String token);
-    List<UserFcm> findAllByUserSeqAndState(Long userSeq, Boolean state);
 }

--- a/src/main/java/com/mozi/moziserver/service/ScheduleService.java
+++ b/src/main/java/com/mozi/moziserver/service/ScheduleService.java
@@ -106,11 +106,13 @@ public class ScheduleService {
                 userNoticeService.upsertUserNotice(user, UserNoticeType.POSTBOX_MESSAGE_ANIMAL_RECEIVED_ITEM, lastPostboxMessageAnimal.getSeq());
             });
 
-            if (lastPostboxMessageAnimal.getLevel() == 3 && lastPostboxMessageAnimal.getAnimal().getIslandLevel() < Constant.islandMaxLevel)
-                fcmService.sendMessageToUser(lastPostboxMessageAnimal.getUser(), FcmMessageType.POSTBOX_MESSAGE_ANIMAL_RECEIVED_ITEM);
+            if (lastPostboxMessageAnimal.getLevel() == 3 && lastPostboxMessageAnimal.getAnimal().getIslandLevel() < Constant.islandMaxLevel) {
+                fcmService.sendMessageToUser(lastPostboxMessageAnimal.getUser(), FcmMessageType.POSTBOX_MESSAGE_ANIMAL_NEW_ARRIVED);
+            }
+
 
             fcmService.sendMessageToUser(lastPostboxMessageAnimal.getUser(), FcmMessageType.NEW_POST_BOX_MESSAGE);
-            fcmService.sendMessageToUser(lastPostboxMessageAnimal.getUser(), FcmMessageType.POSTBOX_MESSAGE_ANIMAL_NEW_ARRIVED);
+            fcmService.sendMessageToUser(lastPostboxMessageAnimal.getUser(), FcmMessageType.POSTBOX_MESSAGE_ANIMAL_RECEIVED_ITEM);
         }
     }
 

--- a/src/main/java/com/mozi/moziserver/service/ScheduleService.java
+++ b/src/main/java/com/mozi/moziserver/service/ScheduleService.java
@@ -1,6 +1,5 @@
 package com.mozi.moziserver.service;
 
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 import com.mozi.moziserver.common.Constant;
 import com.mozi.moziserver.model.entity.*;
 import com.mozi.moziserver.model.mappedenum.FcmMessageType;
@@ -14,7 +13,6 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
 
-import javax.transaction.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -37,20 +35,12 @@ public class ScheduleService {
     private final FcmService fcmService;
     private final UserNoticeService userNoticeService;
 
-    @Transactional
-    @Scheduled(cron = "0 0 0 * * *")
-//    For test
+
+    //    For test
 //    @Scheduled(initialDelay = 1000L, fixedDelay = 100000000000000L)
+    @Scheduled(cron = "0 0 0 * * *")
     public void updateUserChallenge() {
         final LocalDate today = LocalDate.now();
-
-//        TODO 트렌젝션 지연시간 줄이기 위해 변화시킬 방향
-//        try{
-//            전체 조회 ( 조건에 맞는 대상만 가져옴 ) -- 트렌젝션 X
-//
-//            하나 조회 ( 조건에 맞는지 한번더 확인 ) -- 트렌젝션 O
-//            하나 업데이트 -- 트렌젝션 O
-//        } catch () {}
 
         // TODO return 되는 값은 로그로 남긴다.
         userChallengeRepository.updateState(today, UserChallengeStateType.PLAN, UserChallengeStateType.DOING);
@@ -58,36 +48,23 @@ public class ScheduleService {
         updateUserChallengeDoingToEnd(today);
     }
 
-    /**
-     * user challenge state from doing to end
-     *
-     * @param date start date
-     */
     public void updateUserChallengeDoingToEnd(final LocalDate date) {
-        // TODO 트렌젝션 걸기
-
         List<UserChallenge> endedUserChallengeList = userChallengeRepository.findAllByStateAndStartDate(UserChallengeStateType.DOING, date.minusDays(7));
 
         for (UserChallenge userChallenge : endedUserChallengeList) {
-                UserChallenge curUserChallenge = userChallengeRepository.findBySeq(userChallenge.getSeq())
-                        .orElse(null);
-
-                if (curUserChallenge == null) {
-                    // TODO
+            withTransaction(() -> {
+                if (userChallenge.getTotalConfirmCnt() >= userChallenge.getChallenge().getRecommendedCnt()) {
+                    userRewardRepository.incrementPoint(userChallenge.getUser().getSeq(), Constant.challengeExtraPoints);
                 }
 
-                if (curUserChallenge.getTotalConfirmCnt() >= curUserChallenge.getChallenge().getRecommendedCnt()) {
-                    userRewardRepository.incrementPoint(curUserChallenge.getUser().getSeq(), Constant.challengeExtraPoints);
-                }
+                userChallengeRepository.updateUserChallengeState(userChallenge.getSeq(), UserChallengeStateType.DOING, UserChallengeStateType.END);
+            });
 
-                userChallengeRepository.updateUserChallengeState(curUserChallenge.getSeq(), UserChallengeStateType.DOING, UserChallengeStateType.END);
+            fcmService.sendMessageToUser(userChallenge.getUser(), FcmMessageType.END_USER_CHALLENGE_MESSAGE);
         }
-
-        fcmService.sendMessageToAll(FcmMessageType.END_USER_CHALLENGE_MESSAGE);
     }
 
     @Scheduled(cron = "0 0 21 ? * SUN")
-//    @Scheduled(initialDelay = 1000L, fixedDelay = 100000000000000L) //    For test
     public void updatePostboxAnimalByUserPointRecord() {
 
         final LocalDate today = LocalDate.now();
@@ -104,11 +81,6 @@ public class ScheduleService {
 
         // 2. 조건에 만족하는 유저면 포스트박스와 상황에 맞게 유저 아일랜드를 업그레이드 해준다.
         for (User user : accomplishedUser) {
-//            User curUser = userRepository.findById(user.getSeq()).orElse(null);
-//            if (curUser == null) {
-//                // TODO 탈퇴한 유저를 재조회하면 좋음
-//                continue;
-//            }
             PostboxMessageAnimal lastPostboxMessageAnimal = postboxMessageAnimalRepository.findLastOneByUser(user);
 
             // step. 유저가 섬의 '최종 상태'(마지막 동물이 위시리스트를 모두 받은 상태)인지 확인
@@ -119,7 +91,6 @@ public class ScheduleService {
             if (isLastPostboxMessageAnimalStateInIsland) continue;
 
             withTransaction(() -> {
-
                 lastPostboxMessageAnimal.setLevel(lastPostboxMessageAnimal.getLevel() + 1);
                 lastPostboxMessageAnimal.setCheckedState(false);
                 postboxMessageAnimalRepository.save(lastPostboxMessageAnimal);
@@ -128,19 +99,18 @@ public class ScheduleService {
                     if (lastPostboxMessageAnimal.getAnimal().getIslandLevel() < Constant.islandMaxLevel) {
                         Animal nextAnimal = animalRepository.findByIslandTypeAndIslandLevel(lastPostboxMessageAnimal.getAnimal().getIslandType(), lastPostboxMessageAnimal.getAnimal().getIslandLevel() + 1);
                         postboxMessageAnimalService.createPostboxMessageAnimal(user, nextAnimal);
-                    }
-
-                    if (lastPostboxMessageAnimal.getAnimal().getIslandLevel() < Constant.islandMaxLevel) {
                         userIslandRepository.updateUserIslandRewardLevel(user.getSeq(), lastPostboxMessageAnimal.getAnimal().getIslandType());
                     }
                 }
-
+                
                 userNoticeService.upsertUserNotice(user, UserNoticeType.POSTBOX_MESSAGE_ANIMAL_RECEIVED_ITEM, lastPostboxMessageAnimal.getSeq());
             });
 
-            fcmService.sendMessageToUser(lastPostboxMessageAnimal.getUser(), FcmMessageType.NEW_POST_BOX_MESSAGE);
+            if (lastPostboxMessageAnimal.getLevel() == 3 && lastPostboxMessageAnimal.getAnimal().getIslandLevel() < Constant.islandMaxLevel)
+                fcmService.sendMessageToUser(lastPostboxMessageAnimal.getUser(), FcmMessageType.POSTBOX_MESSAGE_ANIMAL_RECEIVED_ITEM);
 
-            fcmService.sendMessageToAll(FcmMessageType.USER_NOTICE_POSTBOX_MESSAGE_ANIMAL_MESSAGE);
+            fcmService.sendMessageToUser(lastPostboxMessageAnimal.getUser(), FcmMessageType.NEW_POST_BOX_MESSAGE);
+            fcmService.sendMessageToUser(lastPostboxMessageAnimal.getUser(), FcmMessageType.POSTBOX_MESSAGE_ANIMAL_NEW_ARRIVED);
         }
     }
 


### PR DESCRIPTION
## 개요 
- Issue #24
- FcmMessageType 타입 추가, Fcm 푸시 알림 관련 로직 수정

### 세부 작업 내용
- FcmMessageType 추가 
  - POSTBOX_MESSAGE_ANIMAL_RECEIVED_ITEM
  - POSTBOX_MESSAGE_ANIMAL_NEW_ARRIVED
- UserFcm upsert 메서드 코드 정리(기능 변경 없음)
- 동물의 편지가 새로 도착하는 경우와 동물의 편지의 아이템이 새로 도착하는 경우 모두 FCM 푸시 알림이 가도록 기능 추가
- UserFcm의 token이 유효하지 않을시 state를 false로 바꾸는 방식에서 에러로그 남기는 방식으로 변경
  (등록되지 않은 토큰을 가지고 있는 UserFcm 의 state를 false로 만들어서 사용하지 않는 것보다 에러로그를 남겨 파악은 하지만 토큰 사용은 유효하도록 놔두는 것이 낫다고 판단했습니다.)
- FcmService에 있는 메서드와 같이 외부 API를 호출하는 로직을 트렌젝션 안에 묶지 않기 위해 updateUserChallenge 스케쥴 메서드의 @Transactional를 제거하고 withTransaction메서드를 통해 일부 코드영역만을 트렌젝션하게 진행
- 새로운 동물의 편지가 도착했을때 FcmMessageType.POSTBOX_MESSAGE_ANIMAL_NEW_ARRIVED가 보내지도록 코드 수정

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/#24 -> dev

### 특이 사항 (optional)
- DB의 UserFcm은 유저당 하나만 가지므로 가장 최근 FCM 토큰 등록을 한 토큰으로 FCM 푸시 알림이 가도록 되어있습니다.
 ( + 유저가 하나의 계정으로 여러 계정에 동시 로그인 하는 것을 막아야 합니다.)