### PR TITLE
[fix] #5 - Modify the email format

### DIFF
--- a/src/main/java/com/mozi/moziserver/service/EmailAuthService.java
+++ b/src/main/java/com/mozi/moziserver/service/EmailAuthService.java
@@ -72,8 +72,8 @@ public class EmailAuthService {
 
         boolean isSend = sendEmail(
                 emailAuth.getId(),
-                "가입 인증 메일",
-                "<html> <body><h1></h1>" + "<br/>아래 [인증] 버튼을 눌러주세요." + "<form action=\"" + serverDomain + "/email/auth/" + emailAuth.getToken() + "\"> <input type=\"submit\" value=\"인증\" /> </form>"
+                "[제로리] 가입 인증 메일",
+                "<html> <body><h3>안녕하세요. 제로리입니다.</h3>" + "아래 [인증] 버튼을 눌러주세요." + "<form action=\"" + serverDomain + "/email/auth/" + emailAuth.getToken() + "\"> <input type=\"submit\" value=\"인증\" /> </form>"
                         + "</body></html>"
 //                "인증링크 : " + serverDomain + "/email/auth/" + emailAuth.getToken()
         );
@@ -110,11 +110,13 @@ public class EmailAuthService {
 
         saveEmailAuth(emailAuth);
 
-        String content="<h1>회원님의 임시 비밀번호는 " + tempPassword + " 입니다." + "로그인 후에 비밀번호를 변경을 해주세요</h1>";
+
+        String content="<h1>안녕하세요. 제로리입니다.<br/> 회원님의 임시 비밀번호는 " + tempPassword + " 입니다.<br/>" + "로그인 후에 비밀번호를 변경을 해주세요.</h1>";
 
         boolean isSend = sendEmail(
                 emailAuth.getId(),
-                "비밀번호 재설정 메일",content
+                "[제로리] 비밀번호 재설정 메일",
+                content
         );
 
         if (!isSend) {
@@ -139,7 +141,7 @@ public class EmailAuthService {
      * @param userAuth
      * @param newEmail
      */
-    public void sendResetEmailEmail(UserAuth userAuth, String newEmail) {
+    public void sendResetEmail(UserAuth userAuth, String newEmail) {
         if (userAuth.getType() != UserAuthType.EMAIL) {
             throw ResponseError.InternalServerError.UNEXPECTED_ERROR.getResponseException();
         }
@@ -154,8 +156,8 @@ public class EmailAuthService {
 
         boolean isSend = sendEmail(
                 newEmail,
-                "이메일 변경 인증 메일",
-                "<html> <body><h1></h1>" + "<br/>아래 [인증] 버튼을 눌러주세요." + "<form action=\"" + serverDomain + "/email/auth/" + emailAuth.getToken() + "\"> <input type=\"submit\" value=\"인증\" /> </form>"
+                "[제로리] 이메일 변경 인증 메일",
+                "<html> <body><h3>안녕하세요. 제로리입니다.</h3>" + "아래 [인증] 버튼을 눌러주세요." + "<form action=\"" + serverDomain + "/email/auth/" + emailAuth.getToken() + "\"> <input type=\"submit\" value=\"인증\" /> </form>"
                         + "</body></html>"
         );
 
@@ -262,7 +264,7 @@ public class EmailAuthService {
             MimeMessageHelper messageHelper = new MimeMessageHelper(message, true, "UTF-8");
             messageHelper.setSubject(title);
             messageHelper.setTo(to);
-            messageHelper.setFrom(emailAddress);
+            messageHelper.setFrom("제로리 "+"<"+emailAddress+">");
             messageHelper.setText(content, true);
             emailSender.send(message);
         } catch (Exception e) {

--- a/src/main/java/com/mozi/moziserver/service/UserService.java
+++ b/src/main/java/com/mozi/moziserver/service/UserService.java
@@ -301,7 +301,7 @@ public class UserService {
             throw ResponseError.BadRequest.INVALID_EMAIL.getResponseException();
         }
 
-        emailAuthService.sendResetEmailEmail(userAuth, email);
+        emailAuthService.sendResetEmail(userAuth, email);
     }
 
     public UserAuth findUserAuthByNicknameAndPw(String nickName, String pw) {

--- a/src/main/resources/static/email-auth-reset-pw-valid.html
+++ b/src/main/resources/static/email-auth-reset-pw-valid.html
@@ -1,4 +1,4 @@
-email-auth-join-valid.html<!DOCTYPE html>
+<!DOCTYPE html>
 <html>
   <meta charset="utf-8"/>
   <head>


### PR DESCRIPTION
## 개요 
- Issue #5 
- 가입/비밀번호/이메일 확인용 이메일 형식 수정하기

### 세부 작업 내용
- 이메일 제목,보내는 사람,이메일 내용을 제로리 애플리케이션에서 보낸 것을 알 수 있도록 수정
- 이메일 변경 함수 이름 변경
- 비밀번호 변경 HTML 파일 수정

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/#5 -> dev

### 테스트 결과 (optional)
아래 사진은 수정된 화면입니다.

<img width="401" alt="스크린샷 2023-01-22 오후 5 03 27" src="https://user-images.githubusercontent.com/47858282/213906366-bf33afdf-3fbe-41eb-b259-642849177555.png">


### 특이 사항 (optional)
