### PR TITLE
[fix] #35 - Separate the Sentry Environment / Add minimum log level about sentry

### DIFF
--- a/src/main/resources/application-default.yml
+++ b/src/main/resources/application-default.yml
@@ -1,2 +1,6 @@
 server:
   domain: http://localhost:8080
+
+sentry:
+  logging:
+    enabled: false

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,2 +1,5 @@
 server:
   domain: https://dev.zero-ri.com
+
+sentry:
+  environment: dev

--- a/src/main/resources/application-production.yml
+++ b/src/main/resources/application-production.yml
@@ -6,3 +6,6 @@ server:
 springfox:
   documentation:
     enabled: false
+
+sentry:
+  environment: production

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,3 +58,5 @@ sentry:
   stacktrace:
     app-packages:
       - com.mozi.moziserver
+  logging:
+    minimum-event-level: warn


### PR DESCRIPTION
## 개요 
- Issue #35 
- sentry의 dev, production 환경 분리와 local log 남지 않게 하기
- logging level을 warn 이상으로 수정

### 세부 작업 내용
- profile 별로(dev,production) sentry에 나오는 environment 설정
- logging level이 warn으로 설정하여 그 이상의 log 메세지 남도록 application.yml 수정

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feature/#35 -> dev

### 테스트 결과 (optional)

### 특이 사항 (optional)
