### PR TITLE
[fix] Resolve LazyInitializationException that occurs when executing …

### DIFF
--- a/src/main/java/com/mozi/moziserver/repository/UserChallengeRepository.java
+++ b/src/main/java/com/mozi/moziserver/repository/UserChallengeRepository.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 
 @Repository
 public interface UserChallengeRepository extends JpaRepository<UserChallenge, Long>, UserChallengeRepositorySupport {
+
     @Transactional
     @Modifying(clearAutomatically = true)
     @Query("UPDATE user_challenge SET state = :afterState WHERE seq = :seq AND state = :beforeState")
@@ -24,8 +25,6 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
             @Param("beforeState") UserChallengeStateType beforeState,
             @Param("afterState") UserChallengeStateType afterState
     );
-
-    List<UserChallenge> findAllByStateAndStartDate(UserChallengeStateType stateType, LocalDate startDate);
 
     Optional<UserChallenge> findFirstByStateNotAndUserSeqOrderByStartDateAsc(UserChallengeStateType userChallengeStateType, Long userSeq);
 }

--- a/src/main/java/com/mozi/moziserver/repository/UserChallengeRepositoryImpl.java
+++ b/src/main/java/com/mozi/moziserver/repository/UserChallengeRepositoryImpl.java
@@ -161,8 +161,16 @@ public class UserChallengeRepositoryImpl extends QuerydslRepositorySupport imple
         return resultCount;
     }
 
+    @Override
+    public List<UserChallenge> findAllByStateAndStartDate(UserChallengeStateType stateType, LocalDate startDate) {
+        return from(qUserChallenge)
+                .innerJoin(qUserChallenge.challenge, qChallenge).fetchJoin()
+                .where(qUserChallenge.state.eq(stateType)
+                        .and(qUserChallenge.startDate.eq(startDate)))
+                .fetch();
+    }
+
     private <T> Predicate predicateOptional(final Function<T, Predicate> whereFunc, final T value) {
         return value != null ? whereFunc.apply(value) : null;
     }
-
 }

--- a/src/main/java/com/mozi/moziserver/repository/UserChallengeRepositorySupport.java
+++ b/src/main/java/com/mozi/moziserver/repository/UserChallengeRepositorySupport.java
@@ -42,4 +42,6 @@ public interface UserChallengeRepositorySupport {
             UserChallengeStateType beforeState,
             UserChallengeStateType afterState
     );
+
+    List<UserChallenge> findAllByStateAndStartDate(UserChallengeStateType stateType, LocalDate startDate);
 }

--- a/src/main/java/com/mozi/moziserver/service/UserChallengeService.java
+++ b/src/main/java/com/mozi/moziserver/service/UserChallengeService.java
@@ -345,6 +345,5 @@ public class UserChallengeService {
     ) {
 
         return userChallengeRecordRepository.findByUserAndConfirmCnt(userSeq,reqList.getPrevLastSeq(),reqList.getPageSize());
-
     }
 }


### PR DESCRIPTION
## 개요 
- Issue 33
- 일주일 챌린지가 일주일이 지나도 자동 완료 상태가 안되는 오류 수정

### 세부 작업 내용
- userChallenge 와 연관관계인 challenge 엔티티가 LAZY LOADING이기 때문에 userChallenge.getChallenge.getRecommendedCnt() 실행시 LazyInitializationException발생 ->
QueryDSL에서 fetchJoin을 사용하여 UserChallnge 조회시 관련 Challenge 엔티티 정보 한번에 가져옴

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) hotfix/#33 -> dev

### 테스트 결과 (optional)
dev 데이터베이스를 바탕으로 테스트 결과 정상 동작

### 특이 사항 (optional)
- 테스트 중, UserChallenge와 연관관계를 가진 Challenge(seq = 24)가 dev 데이터베이스에 없는 것을 발견했습니다. -> 데이터 확인 결과 challenge 데이터가 seq=17이후로 없습니다. ->  challenge 테이블에 백업 데이터 모두 넣었습니다.
