### PR TITLE
[fix] Resolve NullPointerException about sendMessage

### DIFF
--- a/src/main/java/com/mozi/moziserver/service/FcmService.java
+++ b/src/main/java/com/mozi/moziserver/service/FcmService.java
@@ -33,7 +33,7 @@ public class FcmService {
             log.debug(response);
         } catch (FirebaseMessagingException e) {
             log.error("FIREBASE_MESSAGING_EXCEPTION", e);
-            if (e.getMessagingErrorCode().equals(MessagingErrorCode.UNREGISTERED)) {
+            if (e.getMessagingErrorCode() == MessagingErrorCode.UNREGISTERED) {
                 log.error("UNREGISTERED_TOKEN", e);
             }
         }


### PR DESCRIPTION
## 개요 
- Issue #38
- NullPointerException 해결

### 세부 작업 내용
- sendMessage의 if문에서 NullPointerException 발생했으므로 equals를 ==으로 수정

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) hotfix/#38 -> dev

### 테스트 결과 (optional)

### 특이 사항 (optional)
