### PR TITLE
[feat] Add delete island admin API

### DIFF
--- a/src/main/java/com/mozi/moziserver/adminController/AdminIslandController.java
+++ b/src/main/java/com/mozi/moziserver/adminController/AdminIslandController.java
@@ -47,23 +47,23 @@ public class AdminIslandController {
     }
 
     @ApiOperation("섬 등록")
-    @PostMapping(value = "/admin/islands",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(value = "/admin/islands", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Object> createIsland(
             @ApiParam(hidden = true) @SessionUser Long userSeq,
             @RequestParam(value = "name", required = true) String name,
             @RequestParam(value = "type", required = true) Integer type,
             @RequestParam(value = "description", required = true) String description,
-            @RequestParam(value = "maxPoint",required = true) Integer maxPoint,
+            @RequestParam(value = "maxPoint", required = true) Integer maxPoint,
             @RequestParam(value = "maxRewardLevel", required = true) Integer maxRewardLevel,
-            @RequestPart(value = "islandImgUrlList",required = true) List<MultipartFile> islandImgUrlList,
-            @RequestPart(value = "islandThumbnailImgUrlList",required = true) List<MultipartFile> islandThumbnailImgUrlList
+            @RequestPart(value = "islandImgUrlList", required = true) List<MultipartFile> islandImgUrlList,
+            @RequestPart(value = "islandThumbnailImgUrlList", required = true) List<MultipartFile> islandThumbnailImgUrlList
     ) {
         if (islandImgUrlList.size() != Constant.islandMaxLevel ||
-                islandThumbnailImgUrlList.size() != Constant.islandMaxLevel){
+                islandThumbnailImgUrlList.size() != Constant.islandMaxLevel) {
             throw ResponseError.BadRequest.INVALID_IMAGE.getResponseException("need to 6 images");
         }
 
-        adminIslandService.createIsland(type, name, description,maxPoint,maxRewardLevel,islandImgUrlList, islandThumbnailImgUrlList);
+        adminIslandService.createIsland(type, name, description, maxPoint, maxRewardLevel, islandImgUrlList, islandThumbnailImgUrlList);
 
         return new ResponseEntity<>(HttpStatus.OK);
     }
@@ -73,12 +73,12 @@ public class AdminIslandController {
     public ResponseEntity<Object> updateIsland(
             @ApiParam(hidden = true) @SessionUser Long userSeq,
             @PathVariable(value = "type", required = true) Integer type,
-            @RequestParam("name") String name,
-            @RequestParam("description") String description,
-            @RequestParam("maxPoint") Integer maxPoint,
-            @RequestParam("maxRewardLevel") Integer maxRewardLevel
+            @RequestParam(value = "name", required = false) String name,
+            @RequestParam(value = "description", required = false) String description,
+            @RequestParam(value = "maxPoint", required = false) Integer maxPoint,
+            @RequestParam(value = "maxRewardLevel", required = false) Integer maxRewardLevel
     ) {
-        if (name != null || description != null || maxPoint !=null || maxRewardLevel !=null) {
+        if (name != null || description != null || maxPoint != null || maxRewardLevel != null) {
             adminIslandService.updateIsland(type, name, description, maxPoint, maxRewardLevel);
         }
 
@@ -97,6 +97,17 @@ public class AdminIslandController {
         if (islandImg != null || islandThumbnailImg != null) {
             adminIslandService.updateIslandImg(type, level, islandImg, islandThumbnailImg);
         }
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @ApiOperation("섬 삭제")
+    @DeleteMapping("/admin/islands/{type}")
+    public ResponseEntity<Object> deleteIsland(
+            @ApiParam(hidden = true) @SessionUser Long userSeq,
+            @PathVariable(value = "type", required = true) Integer type
+    ) {
+        adminIslandService.deleteIsland(type);
 
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/src/main/java/com/mozi/moziserver/adminService/AdminIslandService.java
+++ b/src/main/java/com/mozi/moziserver/adminService/AdminIslandService.java
@@ -7,7 +7,6 @@ import com.mozi.moziserver.model.entity.IslandImg;
 import com.mozi.moziserver.repository.IslandImgRepository;
 import com.mozi.moziserver.repository.IslandRepository;
 import com.mozi.moziserver.service.S3ImageService;
-import io.swagger.models.auth.In;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -190,6 +189,14 @@ public class AdminIslandService {
         } catch (Exception e) {
             throw new RuntimeException(e.getCause());
         }
+    }
+
+    @Transactional
+    public void deleteIsland(Integer type) {
+        final Island island = getIsland(type);
+
+        islandRepository.delete(island);
+        islandImgRepository.deleteByType(island.getType());
     }
 
     private void withTransaction(Runnable runnable) {

--- a/src/main/java/com/mozi/moziserver/repository/IslandImgRepository.java
+++ b/src/main/java/com/mozi/moziserver/repository/IslandImgRepository.java
@@ -3,10 +3,14 @@ package com.mozi.moziserver.repository;
 import com.mozi.moziserver.model.entity.IslandImg;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Repository
 public interface IslandImgRepository extends JpaRepository<IslandImg, Integer> ,IslandImgRepositorySupport{
     public List<IslandImg> findAllByType(Integer type);
+
+    @Transactional
+    public void deleteByType(Integer type);
 }


### PR DESCRIPTION
## 개요 
- Issue #47
- Island 어드민 API 수정 및 기능 추가

### 세부 작업 내용
- 섬 수정 API type을 제외한 파라미터는 넘기는 필드만 변경할 수 있도록 required=false 상태로 바꾸기
- 섬 삭제 API 추가

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) hotfix/#47 -> dev

### 테스트 결과 (optional)
swagger 테스트 완료
