### PR TITLE
[feat] #44 - Add get and change function to user's tutorial checked s…

### DIFF
--- a/src/main/java/com/mozi/moziserver/controller/ConfigurationController.java
+++ b/src/main/java/com/mozi/moziserver/controller/ConfigurationController.java
@@ -78,6 +78,16 @@ public class ConfigurationController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
+    @ApiOperation("튜토리얼 확인 완료")
+    @PutMapping("/v1/users/me/tutorial/checked")
+    public ResponseEntity<Object> checkedTutorial(
+            @ApiParam(hidden = true) @SessionUser Long userSeq
+    ) {
+        userService.checkTutorial(userSeq);
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
     @ApiOperation("챌린지 제안하기")
     @PostMapping("/v1/suggestions")
     public ResponseEntity<Object> createSuggestion(

--- a/src/main/java/com/mozi/moziserver/model/entity/User.java
+++ b/src/main/java/com/mozi/moziserver/model/entity/User.java
@@ -1,6 +1,7 @@
 package com.mozi.moziserver.model.entity;
 
 import com.mozi.moziserver.common.UserState;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -22,6 +23,9 @@ public class User extends AbstractTimeEntity {
     private UserState state = UserState.ACTIVE;
 
     private String stateReason;
+
+    @Builder.Default
+    private boolean tutorialCheckedState = false;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "seq")

--- a/src/main/java/com/mozi/moziserver/model/res/ResUserInfo.java
+++ b/src/main/java/com/mozi/moziserver/model/res/ResUserInfo.java
@@ -9,11 +9,13 @@ public class ResUserInfo {
     private Long seq;
     private String nickName;
     private String email;
+    private boolean tutorialCheckedState;
 
     private ResUserInfo(User user){
         this.seq = user.getSeq();
         this.nickName = user.getNickName();
         this.email = user.getEmail();
+        this.tutorialCheckedState = user.isTutorialCheckedState();
     }
 
     public static ResUserInfo of(User user) {

--- a/src/main/java/com/mozi/moziserver/service/UserService.java
+++ b/src/main/java/com/mozi/moziserver/service/UserService.java
@@ -418,6 +418,16 @@ public class UserService {
         // TODO DeleteLog에 삭제된 회원정보 넣기
     }
 
+    @Transactional
+    public void checkTutorial(Long userSeq) {
+        User user = userRepository.findById(userSeq)
+                .orElseThrow(ResponseError.NotFound.USER_NOT_EXISTS::getResponseException);
+
+        user.setTutorialCheckedState(true);
+
+        userRepository.save(user);
+    }
+
     private void withTransaction(Runnable runnable) {
         DefaultTransactionDefinition definition = new DefaultTransactionDefinition();
 


### PR DESCRIPTION
## 개요 
- Issue #44
- 유저의 튜토리얼 조회상태 및 조회상태변경(튜토리얼 읽음)에 대한 API 추가

### 세부 작업 내용
- GET /api/v1/users/me의 응답에 '튜토리얼 조회여부' 필드 추가 -> tutorialCheckedState
- '튜토리얼 조회여부' 조회상태로 변경 등록을 위한 PUT /v1/users/me/tutorial/checked API 추가
- User 엔티티에 boolean tutorialCheckedState 필드 추가 

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) hotfix/#44 -> dev

### 테스트 결과 (optional)
ex) swagger 테스트 완료

### 특이 사항 (optional)
- 데이터베이스의 user 테이블에 tutorial_checked_state 칼럼을 추가하였습니다.
